### PR TITLE
Improved Tool resolution

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
@@ -13,6 +13,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         public ICakeEnvironment Environment { get; set; }
         public IProcess Process { get; set; }
         public IProcessRunner ProcessRunner { get; private set; }
+        public IGlobber Globber { get; set; }
 
         public MSBuildSettings Settings { get; set; }
 
@@ -32,6 +33,8 @@ namespace Cake.Common.Tests.Fixtures.Tools
 
             ProcessRunner = Substitute.For<IProcessRunner>();
             ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(Process);
+
+            Globber = Substitute.For<IGlobber>();
 
             Environment = Substitute.For<ICakeEnvironment>();
             Environment.Is64BitOperativeSystem().Returns(is64BitOperativeSystem);
@@ -71,7 +74,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
 
         public void Run()
         {
-            var runner = new MSBuildRunner(FileSystem, Environment, ProcessRunner);
+            var runner = new MSBuildRunner(FileSystem, Environment, ProcessRunner, Globber);
             runner.Run(Settings);
         }
 

--- a/src/Cake.Common.Tests/Fixtures/Tools/MSTestRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSTestRunnerFixture.cs
@@ -11,6 +11,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         public ICakeEnvironment Environment { get; set; }
         public IProcess Process { get; set; }
         public IProcessRunner ProcessRunner { get; set; }
+        public IGlobber Globber { get; set; }
 
         public FilePath ToolPath { get; set; }
 
@@ -23,6 +24,8 @@ namespace Cake.Common.Tests.Fixtures.Tools
 
             ProcessRunner = Substitute.For<IProcessRunner>();
             ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(Process);
+
+            Globber = Substitute.For<IGlobber>();
 
             Environment = Substitute.For<ICakeEnvironment>();
             Environment.WorkingDirectory = "/Working";
@@ -39,7 +42,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
 
         public MSTestRunner CreateRunner()
         {
-            return new MSTestRunner(FileSystem, Environment, ProcessRunner);
+            return new MSTestRunner(FileSystem, Environment, ProcessRunner, Globber);
         }
     }
 }

--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetInstallerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetInstallerFixture.cs
@@ -18,13 +18,13 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet
 
         public void Install()
         {
-            var tool = new NuGetInstaller(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+            var tool = new NuGetInstaller(FileSystem, Environment, ProcessRunner, Globber, NuGetToolResolver);
             tool.Install(PackageId, Settings);
         }
 
         public void InstallFromConfig()
         {
-            var tool = new NuGetInstaller(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+            var tool = new NuGetInstaller(FileSystem, Environment, ProcessRunner, Globber, NuGetToolResolver);
             tool.InstallFromConfig(PackageConfigPath, Settings);
         }
     }

--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetPackerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetPackerFixture.cs
@@ -29,7 +29,7 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet
 
         public void Pack()
         {
-            var tool = new NuGetPacker(FileSystem, Environment, ProcessRunner, Log, NuGetToolResolver);
+            var tool = new NuGetPacker(FileSystem, Environment, ProcessRunner, Log, Globber, NuGetToolResolver);
             tool.Pack(NuSpecFilePath, Settings);
         }
     }

--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetPusherFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetPusherFixture.cs
@@ -16,7 +16,7 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet
 
         public void Push()
         {
-            var tool = new NuGetPusher(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+            var tool = new NuGetPusher(FileSystem, Environment, ProcessRunner, Globber, NuGetToolResolver);
             tool.Push(PackageFilePath, Settings);
         }
     }

--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetRestorerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetRestorerFixture.cs
@@ -16,7 +16,7 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet
 
         public void Restore()
         {
-            var tool = new NuGetRestorer(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+            var tool = new NuGetRestorer(FileSystem, Environment, ProcessRunner, Globber, NuGetToolResolver);
             tool.Restore(TargetFilePath, Settings);
         }
     }

--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetSetApiKeyFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetSetApiKeyFixture.cs
@@ -28,7 +28,7 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet
 
         public void SetApiKey()
         {
-            var tool = new NuGetSetApiKey(Log, FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+            var tool = new NuGetSetApiKey(Log, FileSystem, Environment, ProcessRunner, Globber, NuGetToolResolver);
             tool.SetApiKey(ApiKey, Source, Settings);
         }
     }

--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetSourcesFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetSourcesFixture.cs
@@ -35,19 +35,19 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet
 
         public void AddSources()
         {
-            var tool = new NuGetSources(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+            var tool = new NuGetSources(FileSystem, Environment, ProcessRunner, Globber, NuGetToolResolver);
             tool.AddSource(Name, Source, Settings);
         }
 
         public void RemoveSource()
         {
-            var tool = new NuGetSources(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+            var tool = new NuGetSources(FileSystem, Environment, ProcessRunner, Globber, NuGetToolResolver);
             tool.RemoveSource(Name, Source, Settings);
         }
 
         public void HasSource()
         {
-            var tool = new NuGetSources(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+            var tool = new NuGetSources(FileSystem, Environment, ProcessRunner, Globber, NuGetToolResolver);
             tool.HasSource(Source, Settings);
         }
     }

--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetUpdateFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetUpdateFixture.cs
@@ -19,7 +19,7 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet
 
         public void Update()
         {
-            var tool = new NuGetUpdater(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+            var tool = new NuGetUpdater(FileSystem, Environment, ProcessRunner, Globber, NuGetToolResolver);
             tool.Update(TargetFile, Settings);
         }
     }

--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGetFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGetFixture.cs
@@ -18,6 +18,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         public IProcess Process { get; set; }
         public ICakeLog Log { get; set; }
         public IToolResolver NuGetToolResolver { get; set; }
+        public IGlobber Globber { get; set; }
 
         protected NuGetFixture()
         {
@@ -28,6 +29,10 @@ namespace Cake.Common.Tests.Fixtures.Tools
             Process.GetExitCode().Returns(0);
             ProcessRunner = Substitute.For<IProcessRunner>();
             ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(Process);
+
+            Globber = Substitute.For<IGlobber>();
+            Globber.Match("./tools/**/nuget.exe").Returns(new[] { (FilePath)"/Working/tools/NuGet.exe" });
+            Globber.Match("./tools/**/NuGet.exe").Returns(new[] { (FilePath)"/Working/tools/NuGet.exe" });
 
             NuGetToolResolver = Substitute.For<IToolResolver>();
             NuGetToolResolver.Name.Returns("NuGet");

--- a/src/Cake.Common.Tests/Fixtures/Tools/SignToolSignRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/SignToolSignRunnerFixture.cs
@@ -13,6 +13,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         public IProcessRunner ProcessRunner { get; set; }
         public IRegistry Registry { get; set; }
         public ISignToolResolver Resolver { get; set; }
+        public IGlobber Globber { get;set; }
 
         public IFile AssemblyFile { get; set; }
         public IFile CertificateFile { get; set; }
@@ -42,6 +43,9 @@ namespace Cake.Common.Tests.Fixtures.Tools
             Resolver = Substitute.For<ISignToolResolver>();
             Resolver.GetPath().Returns("/Working/Default/tool.exe");
 
+            Globber = Substitute.For<IGlobber>();
+            Globber.Match("./tools/**/signtool.exe").Returns(new[] { (FilePath)"/Working/Default/tool.exe" });
+
             Environment = Substitute.For<ICakeEnvironment>();
             Environment.WorkingDirectory.Returns("/Working");
 
@@ -50,7 +54,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
 
         public SignToolSignRunner CreateRunner()
         {
-            return new SignToolSignRunner(FileSystem, Environment, ProcessRunner, Registry, Resolver);
+            return new SignToolSignRunner(FileSystem, Environment, ProcessRunner, Globber, Registry, Resolver);
         }
 
         public void RunTool()

--- a/src/Cake.Common/Tools/Cake/CakeRunner.cs
+++ b/src/Cake.Common/Tools/Cake/CakeRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -16,7 +17,6 @@ namespace Cake.Common.Tools.Cake
     public sealed class CakeRunner : Tool<CakeSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
         private readonly IFileSystem _fileSystem;
 
         /// <summary>
@@ -28,10 +28,9 @@ namespace Cake.Common.Tools.Cake
         /// <param name="processRunner">The process runner.</param>
         public CakeRunner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber,
             IProcessRunner processRunner)
-            : base(fileSystem, environment, processRunner)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _environment = environment;
-            _globber = globber;
             _fileSystem = fileSystem;
         }
 
@@ -127,14 +126,12 @@ namespace Cake.Common.Tools.Cake
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the name of the tool executable.
         /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(CakeSettings settings)
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
         {
-            const string expression = "./tools/**/Cake.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return new[] { "Cake.exe" };
         }
     }
 }

--- a/src/Cake.Common/Tools/ILMerge/ILMergeRunner.cs
+++ b/src/Cake.Common/Tools/ILMerge/ILMergeRunner.cs
@@ -13,7 +13,6 @@ namespace Cake.Common.Tools.ILMerge
     public sealed class ILMergeRunner : Tool<ILMergeSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ILMergeRunner" /> class.
@@ -24,10 +23,9 @@ namespace Cake.Common.Tools.ILMerge
         /// <param name="processRunner">The process runner.</param>
         public ILMergeRunner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber,
             IProcessRunner processRunner)
-            : base(fileSystem, environment, processRunner)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _environment = environment;
-            _globber = globber;
         }
 
         /// <summary>
@@ -70,14 +68,12 @@ namespace Cake.Common.Tools.ILMerge
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the name of the tool executable.
         /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(ILMergeSettings settings)
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
         {
-            const string expression = "./tools/**/ILMerge.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return new[] { "ILMerge.exe" };
         }
 
         private ProcessArgumentBuilder GetArguments(FilePath outputAssemblyPath,

--- a/src/Cake.Common/Tools/MSBuild/MSBuildAliases.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildAliases.cs
@@ -43,7 +43,7 @@ namespace Cake.Common.Tools.MSBuild
             var settings = new MSBuildSettings(solution);
             configurator(settings);
 
-            var runner = new MSBuildRunner(context.FileSystem, context.Environment, context.ProcessRunner);
+            var runner = new MSBuildRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
             runner.Run(settings);
         }
     }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -22,8 +23,9 @@ namespace Cake.Common.Tools.MSBuild
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="runner">The runner.</param>
-        public MSBuildRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner runner)
-            : base(fileSystem, environment, runner)
+        /// <param name="globber">The globber.</param>
+        public MSBuildRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner runner, IGlobber globber)
+            : base(fileSystem, environment, runner, globber)
         {
             _fileSystem = fileSystem;
             _environment = environment;
@@ -127,17 +129,33 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(MSBuildSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(MSBuildSettings settings)
         {
             if (settings == null)
             {
                 throw new ArgumentNullException("settings");
             }
-            return MSBuildResolver.GetMSBuildPath(_fileSystem, _environment, settings.ToolVersion, settings.PlatformTarget);
+
+            var path = MSBuildResolver.GetMSBuildPath(_fileSystem, _environment, settings.ToolVersion, settings.PlatformTarget);
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Common/Tools/MSTest/MSTestAliases.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestAliases.cs
@@ -74,7 +74,7 @@ namespace Cake.Common.Tools.MSTest
                 throw new ArgumentNullException("assemblyPaths");
             }
 
-            var runner = new MSTestRunner(context.FileSystem, context.Environment, context.ProcessRunner);
+            var runner = new MSTestRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
             foreach (var assembly in assemblyPaths)
             {
                 runner.Run(assembly, settings);

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Utilities;
@@ -19,8 +21,9 @@ namespace Cake.Common.Tools.MSTest
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
-        public MSTestRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner)
-            : base(fileSystem, environment, processRunner)
+        /// <param name="globber">The globber.</param> 
+        public MSTestRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _fileSystem = fileSystem;
             _environment = environment;
@@ -70,21 +73,29 @@ namespace Cake.Common.Tools.MSTest
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(MSTestSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(MSTestSettings settings)
         {
             foreach (var version in new[] { "12.0", "11.0", "10.0" })
             {
                 var path = GetToolPath(version);
                 if (_fileSystem.Exist(path))
                 {
-                    return path;
+                    yield return path;
                 }
             }
-            return null;
         }
 
         private FilePath GetToolPath(string version)

--- a/src/Cake.Common/Tools/NSIS/MakeNSISRunner.cs
+++ b/src/Cake.Common/Tools/NSIS/MakeNSISRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Cake.Core;
@@ -14,7 +15,6 @@ namespace Cake.Common.Tools.NSIS
     public sealed class MakeNSISRunner : Tool<MakeNSISSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MakeNSISRunner"/> class.
@@ -24,7 +24,7 @@ namespace Cake.Common.Tools.NSIS
         /// <param name="globber">The globber.</param>
         /// <param name="processRunner">The process runner.</param>
         public MakeNSISRunner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner processRunner)
-            : base(fileSystem, environment, processRunner)
+            : base(fileSystem, environment, processRunner, globber)
         {
             if (environment == null)
             {
@@ -37,7 +37,6 @@ namespace Cake.Common.Tools.NSIS
             }
 
             _environment = environment;
-            _globber = globber;
         }
 
         /// <summary>
@@ -70,14 +69,12 @@ namespace Cake.Common.Tools.NSIS
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
         /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(MakeNSISSettings settings)
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
         {
-            const string expression = "./tools/**/makensis.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return new[] { "makensis.exe" };
         }
 
         private ProcessArgumentBuilder GetArguments(FilePath scriptFile, MakeNSISSettings settings)

--- a/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
@@ -14,7 +14,6 @@ namespace Cake.Common.Tools.NUnit
     public sealed class NUnitRunner : Tool<NUnitSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NUnitRunner"/> class.
@@ -24,10 +23,9 @@ namespace Cake.Common.Tools.NUnit
         /// <param name="globber">The globber.</param>
         /// <param name="processRunner">The process runner.</param>
         public NUnitRunner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner processRunner)
-            : base(fileSystem, environment, processRunner)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _environment = environment;
-            _globber = globber;
         }
 
         /// <summary>
@@ -165,14 +163,12 @@ namespace Cake.Common.Tools.NUnit
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
         /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(NUnitSettings settings)
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
         {
-            const string expression = "./tools/**/nunit-console.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return new[] { "nunit-console.exe" };
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Install/NuGetInstaller.cs
+++ b/src/Cake.Common/Tools/NuGet/Install/NuGetInstaller.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Utilities;
@@ -19,10 +21,11 @@ namespace Cake.Common.Tools.NuGet.Install
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param> 
         /// <param name="nugetToolResolver">The NuGet tool resolver.</param>
         public NuGetInstaller(IFileSystem fileSystem, ICakeEnvironment environment, 
-            IProcessRunner processRunner, IToolResolver nugetToolResolver)
-            : base(fileSystem, environment, processRunner)
+            IProcessRunner processRunner, IGlobber globber, IToolResolver nugetToolResolver)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _environment = environment;
             _nugetToolResolver = nugetToolResolver;
@@ -162,13 +165,28 @@ namespace Cake.Common.Tools.NuGet.Install
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "NuGet.exe", "nuget.exe" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(NuGetInstallSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(NuGetInstallSettings settings)
         {
-            return _nugetToolResolver.ResolveToolPath();
+            var path = _nugetToolResolver.ResolveToolPath();
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
+++ b/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
@@ -64,7 +64,7 @@ namespace Cake.Common.Tools.NuGet
             }
 
             var packer = new NuGetPacker(context.FileSystem, context.Environment, 
-                context.ProcessRunner, context.Log, context.GetToolResolver("NuGet"));
+                context.ProcessRunner, context.Log, context.Globber, context.GetToolResolver("NuGet"));
             packer.Pack(nuspecFilePath, settings);
         }
 
@@ -120,7 +120,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetRestorer(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var runner = new NuGetRestorer(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             runner.Restore(targetFilePath, settings);
         }
 
@@ -152,7 +152,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var packer = new NuGetPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var packer = new NuGetPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             packer.Push(packageFilePath, settings);
         }
 
@@ -224,7 +224,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetSources(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var runner = new NuGetSources(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             runner.AddSource(name, source, settings);
         }
 
@@ -296,7 +296,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetSources(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var runner = new NuGetSources(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             runner.RemoveSource(name, source, settings);
         }
 
@@ -377,7 +377,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetSources(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var runner = new NuGetSources(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             return runner.HasSource(source, settings);
         }
 
@@ -424,7 +424,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetInstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var runner = new NuGetInstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             runner.Install(packageId, settings);
         }
         
@@ -471,7 +471,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetInstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var runner = new NuGetInstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             runner.InstallFromConfig(packageConfigPath, settings);
         }
 
@@ -492,7 +492,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetSetApiKey(context.Log, context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var runner = new NuGetSetApiKey(context.Log, context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             runner.SetApiKey(apiKey, source, settings);
         }
 
@@ -530,7 +530,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetUpdater(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var runner = new NuGetUpdater(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             runner.Update(targetFile, new NuGetUpdateSettings());
         }
 
@@ -557,7 +557,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetUpdater(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            var runner = new NuGetUpdater(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             runner.Update(targetFile, settings);
         }
     }

--- a/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -23,11 +25,12 @@ namespace Cake.Common.Tools.NuGet.Pack
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
         /// <param name="log">The log.</param>
+        /// <param name="globber">The globber.</param>
         /// <param name="nugetToolResolver">The NuGet tool resolver</param>
         public NuGetPacker(IFileSystem fileSystem, ICakeEnvironment environment,
-            IProcessRunner processRunner, ICakeLog log,
+            IProcessRunner processRunner, ICakeLog log, IGlobber globber,
             IToolResolver nugetToolResolver)
-            : base(fileSystem, environment, processRunner)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _fileSystem = fileSystem;
             _environment = environment;
@@ -128,13 +131,28 @@ namespace Cake.Common.Tools.NuGet.Pack
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "NuGet.exe", "nuget.exe" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(NuGetPackSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(NuGetPackSettings settings)
         {
-            return _nugetToolResolver.ResolveToolPath();
+            var path = _nugetToolResolver.ResolveToolPath();
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Push/NuGetPusher.cs
+++ b/src/Cake.Common/Tools/NuGet/Push/NuGetPusher.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Utilities;
@@ -20,10 +22,11 @@ namespace Cake.Common.Tools.NuGet.Push
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
         /// <param name="nugetToolResolver">The NuGet tool resolver.</param>
         public NuGetPusher(IFileSystem fileSystem, ICakeEnvironment environment,
-            IProcessRunner processRunner, IToolResolver nugetToolResolver)
-            : base(fileSystem, environment, processRunner)
+            IProcessRunner processRunner, IGlobber globber, IToolResolver nugetToolResolver)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _environment = environment;
             _nugetToolResolver = nugetToolResolver;
@@ -99,13 +102,28 @@ namespace Cake.Common.Tools.NuGet.Push
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "NuGet.exe", "nuget.exe" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(NuGetPushSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(NuGetPushSettings settings)
         {
-            return _nugetToolResolver.ResolveToolPath();
+            var path = _nugetToolResolver.ResolveToolPath();
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
+++ b/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Utilities;
@@ -19,10 +21,11 @@ namespace Cake.Common.Tools.NuGet.Restore
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
         /// <param name="nugetToolResolver">The NuGet tool resolver</param>
         public NuGetRestorer(IFileSystem fileSystem, ICakeEnvironment environment, 
-            IProcessRunner processRunner, IToolResolver nugetToolResolver)
-            : base(fileSystem, environment, processRunner)
+            IProcessRunner processRunner, IGlobber globber, IToolResolver nugetToolResolver)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _environment = environment;
             _nugetToolResolver = nugetToolResolver;
@@ -115,13 +118,28 @@ namespace Cake.Common.Tools.NuGet.Restore
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "NuGet.exe", "nuget.exe" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(NuGetRestoreSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(NuGetRestoreSettings settings)
         {
-            return _nugetToolResolver.ResolveToolPath();
+            var path = _nugetToolResolver.ResolveToolPath();
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/SetApiKey/NuGetSetApiKey.cs
+++ b/src/Cake.Common/Tools/NuGet/SetApiKey/NuGetSetApiKey.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -11,9 +13,8 @@ namespace Cake.Common.Tools.NuGet.SetApiKey
     /// </summary>
     public sealed class NuGetSetApiKey : Tool<NuGetSetApiKeySettings>
     {
-        private readonly ICakeLog _log;
-        private readonly ICakeEnvironment _environment;
         private readonly IToolResolver _nugetToolResolver;
+        private readonly ICakeEnvironment _environment;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NuGetSetApiKey"/> class.
@@ -22,14 +23,14 @@ namespace Cake.Common.Tools.NuGet.SetApiKey
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
         /// <param name="nugetToolResolver">The NuGet tool resolver.</param>
         public NuGetSetApiKey(ICakeLog log, IFileSystem fileSystem, ICakeEnvironment environment, 
-            IProcessRunner processRunner, IToolResolver nugetToolResolver)
-            : base(fileSystem, environment, processRunner)
+            IProcessRunner processRunner, IGlobber globber, IToolResolver nugetToolResolver)
+            : base(fileSystem, environment, processRunner, globber)
         {
-            _log = log;
-            _environment = environment;
             _nugetToolResolver = nugetToolResolver;
+            _environment = environment;
         }
 
         /// <summary>
@@ -109,13 +110,28 @@ namespace Cake.Common.Tools.NuGet.SetApiKey
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "NuGet.exe", "nuget.exe" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(NuGetSetApiKeySettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(NuGetSetApiKeySettings settings)
         {
-            return _nugetToolResolver.ResolveToolPath();
+            var path = _nugetToolResolver.ResolveToolPath();
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Sources/NuGetSources.cs
+++ b/src/Cake.Common/Tools/NuGet/Sources/NuGetSources.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Cake.Core;
@@ -20,10 +21,11 @@ namespace Cake.Common.Tools.NuGet.Sources
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
         /// <param name="nugetToolResolver">The NuGet tool resolver.</param>
         public NuGetSources(IFileSystem fileSystem, ICakeEnvironment environment, 
-            IProcessRunner processRunner, IToolResolver nugetToolResolver)
-            : base(fileSystem, environment, processRunner)
+            IProcessRunner processRunner, IGlobber globber, IToolResolver nugetToolResolver)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _nugetToolResolver = nugetToolResolver;
         }
@@ -211,13 +213,28 @@ namespace Cake.Common.Tools.NuGet.Sources
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "NuGet.exe", "nuget.exe" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(NuGetSourcesSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(NuGetSourcesSettings settings)
         {
-            return _nugetToolResolver.ResolveToolPath();
+            var path = _nugetToolResolver.ResolveToolPath();
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Update/NuGetUpdater.cs
+++ b/src/Cake.Common/Tools/NuGet/Update/NuGetUpdater.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Utilities;
@@ -19,11 +21,13 @@ namespace Cake.Common.Tools.NuGet.Update
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
         /// <param name="nugetToolResolver">The nuget tool resolver.</param>
         public NuGetUpdater(IFileSystem fileSystem,
             ICakeEnvironment environment,
             IProcessRunner processRunner,
-            IToolResolver nugetToolResolver) : base(fileSystem, environment, processRunner)
+            IGlobber globber,
+            IToolResolver nugetToolResolver) : base(fileSystem, environment, processRunner, globber)
         {
             _environment = environment;
             _nugetToolResolver = nugetToolResolver;
@@ -57,13 +61,28 @@ namespace Cake.Common.Tools.NuGet.Update
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "NuGet.exe", "nuget.exe" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(NuGetUpdateSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(NuGetUpdateSettings settings)
         {
-            return _nugetToolResolver.ResolveToolPath();
+            var path = _nugetToolResolver.ResolveToolPath();
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
 
         private ProcessArgumentBuilder GetArguments(FilePath targetFile, NuGetUpdateSettings settings)

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseCreator.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseCreator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
@@ -12,7 +13,6 @@ namespace Cake.Common.Tools.OctopusDeploy
     public sealed class OctopusDeployReleaseCreator : Tool<CreateReleaseSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
 
         /// <summary> 
         /// Initializes a new instance of the <see cref="OctopusDeployReleaseCreator"/> class.
@@ -23,10 +23,9 @@ namespace Cake.Common.Tools.OctopusDeploy
         /// <param name="processRunner">The process runner.</param>
         public OctopusDeployReleaseCreator(IFileSystem fileSystem, ICakeEnvironment environment,
             IGlobber globber, IProcessRunner processRunner) 
-            : base(fileSystem, environment, processRunner)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _environment = environment;
-            _globber = globber;
         }
 
         /// <summary>
@@ -67,13 +66,12 @@ namespace Cake.Common.Tools.OctopusDeploy
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
         /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(CreateReleaseSettings settings)
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return _globber.GetFiles("./tools/**/Octo.exe").FirstOrDefault();
+            return new[] { "Octo.exe" };
         }
     }
 }

--- a/src/Cake.Common/Tools/SignTool/SignToolSignAliases.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignAliases.cs
@@ -153,7 +153,7 @@ namespace Cake.Common.Tools.SignTool
                 throw new ArgumentNullException("settings");
             }
 
-            var runner = new SignToolSignRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Registry);
+            var runner = new SignToolSignRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.Registry);
             foreach (var assembly in assemblies)
             {
                 runner.Run(assembly, settings);

--- a/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Utilities;
@@ -22,11 +24,13 @@ namespace Cake.Common.Tools.SignTool
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
         /// <param name="registry">The registry.</param>
         public SignToolSignRunner(IFileSystem fileSystem,
             ICakeEnvironment environment,
             IProcessRunner processRunner,
-            IRegistry registry) : this(fileSystem, environment, processRunner, registry, null)
+            IGlobber globber,
+            IRegistry registry) : this(fileSystem, environment, processRunner, globber, registry, null)
         {
         }
 
@@ -36,15 +40,17 @@ namespace Cake.Common.Tools.SignTool
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
         /// <param name="registry">The registry.</param>
         /// <param name="resolver">The resolver.</param>
         internal SignToolSignRunner(
             IFileSystem fileSystem,
             ICakeEnvironment environment,
             IProcessRunner processRunner,
+            IGlobber globber,
             IRegistry registry,
             ISignToolResolver resolver)
-            : base(fileSystem, environment, processRunner)
+            : base(fileSystem, environment, processRunner, globber)
         {
             _fileSystem = fileSystem;
             _environment = environment;
@@ -153,14 +159,29 @@ namespace Cake.Common.Tools.SignTool
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(SignToolSignSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(SignToolSignSettings settings)
         {
-            return (settings == null ? null : settings.ToolPath)
-                ?? _resolver.GetPath();
+            var path = _resolver.GetPath();
+
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Common/Tools/WiX/CandleRunner.cs
+++ b/src/Cake.Common/Tools/WiX/CandleRunner.cs
@@ -14,7 +14,6 @@ namespace Cake.Common.Tools.WiX
     public sealed class CandleRunner : Tool<CandleSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CandleRunner"/> class.
@@ -24,18 +23,13 @@ namespace Cake.Common.Tools.WiX
         /// <param name="globber">The globber.</param>
         /// <param name="processRunner">The process runner.</param>
         public CandleRunner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner processRunner)
-            : base(fileSystem, environment, processRunner)
+            : base(fileSystem, environment, processRunner, globber)
         {
             if (environment == null)
             {
                 throw new ArgumentNullException("environment");
             }
-            if (globber == null)
-            {
-                throw new ArgumentNullException("globber");
-            }
             _environment = environment;
-            _globber = globber;
         }
 
         /// <summary>
@@ -170,14 +164,12 @@ namespace Cake.Common.Tools.WiX
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
         /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(CandleSettings settings)
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
         {
-            const string expression = "./tools/**/candle.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return new[] { "candle.exe" };
         }
     }
 }

--- a/src/Cake.Common/Tools/WiX/LightRunner.cs
+++ b/src/Cake.Common/Tools/WiX/LightRunner.cs
@@ -14,7 +14,6 @@ namespace Cake.Common.Tools.WiX
     public sealed class LightRunner : Tool<LightSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LightRunner"/> class.
@@ -24,7 +23,7 @@ namespace Cake.Common.Tools.WiX
         /// <param name="globber">The globber.</param>
         /// <param name="processRunner">The process runner.</param>
         public LightRunner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner processRunner)
-            : base(fileSystem, environment, processRunner)
+            : base(fileSystem, environment, processRunner, globber)
         {
             if (environment == null)
             {
@@ -36,7 +35,6 @@ namespace Cake.Common.Tools.WiX
             }
 
             _environment = environment;
-            _globber = globber;
         }
 
         /// <summary>
@@ -126,14 +124,12 @@ namespace Cake.Common.Tools.WiX
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
         /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(LightSettings settings)
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
         {
-            const string expression = "./tools/**/light.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return new[] { "light.exe" };
         }
     }
 }

--- a/src/Cake.Common/Tools/XBuild/XBuildAliases.cs
+++ b/src/Cake.Common/Tools/XBuild/XBuildAliases.cs
@@ -43,7 +43,7 @@ namespace Cake.Common.Tools.XBuild
             var settings = new XBuildSettings(solution);
             configurator(settings);
 
-            var runner = new XBuildRunner(context.FileSystem, context.Environment, context.ProcessRunner);
+            var runner = new XBuildRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
             runner.Run(settings);
         }
     }

--- a/src/Cake.Common/Tools/XBuild/XBuildRunner.cs
+++ b/src/Cake.Common/Tools/XBuild/XBuildRunner.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -22,8 +23,9 @@ namespace Cake.Common.Tools.XBuild
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="runner">The runner.</param>
-        public XBuildRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner runner)
-            : base(fileSystem, environment, runner)
+        /// <param name="globber">The globber.</param>
+        public XBuildRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner runner, IGlobber globber)
+            : base(fileSystem, environment, runner, globber)
         {
             _fileSystem = fileSystem;
             _environment = environment;
@@ -119,17 +121,34 @@ namespace Cake.Common.Tools.XBuild
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "xunit", "xunit.bat" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(XBuildSettings settings)
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(XBuildSettings settings)
         {
             if (settings == null)
             {
                 throw new ArgumentNullException("settings");
             }
-            return XBuildResolver.GetXBuildPath(_fileSystem, _environment, settings.ToolVersion);
+
+            var path = XBuildResolver.GetXBuildPath(_fileSystem, _environment, settings.ToolVersion);
+
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
@@ -12,7 +12,6 @@ namespace Cake.Common.Tools.XUnit
     public sealed class XUnit2Runner : Tool<XUnit2Settings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="XUnit2Runner" /> class.
@@ -22,10 +21,9 @@ namespace Cake.Common.Tools.XUnit
         /// <param name="globber">The globber.</param>
         /// <param name="runner">The runner.</param>
         public XUnit2Runner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner runner)
-            : base(fileSystem, environment, runner)
+            : base(fileSystem, environment, runner, globber)
         {
             _environment = environment;
-            _globber = globber;
         }
 
         /// <summary>
@@ -109,13 +107,12 @@ namespace Cake.Common.Tools.XUnit
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
         /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(XUnit2Settings settings)
+        /// <returns>The tool executable name.</returns>
+        protected override System.Collections.Generic.IEnumerable<string> GetToolExecutableNames()
         {
-            return _globber.GetFiles("./tools/**/xunit.console.exe").FirstOrDefault();
+            return new[] { "xunit.console.exe" };
         }
     }
 }

--- a/src/Cake.Common/Tools/XUnit/XUnitRunner.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnitRunner.cs
@@ -12,7 +12,6 @@ namespace Cake.Common.Tools.XUnit
     public sealed class XUnitRunner : Tool<XUnitSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="XUnitRunner" /> class.
@@ -22,10 +21,9 @@ namespace Cake.Common.Tools.XUnit
         /// <param name="globber">The globber.</param>
         /// <param name="runner">The runner.</param>
         public XUnitRunner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner runner)
-            : base(fileSystem, environment, runner)
+            : base(fileSystem, environment, runner, globber)
         {
             _environment = environment;
-            _globber = globber;
         }
 
         /// <summary>
@@ -115,13 +113,12 @@ namespace Cake.Common.Tools.XUnit
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets the possible names of the tool executable.
         /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>The default tool path.</returns>
-        protected override FilePath GetDefaultToolPath(XUnitSettings settings)
+        /// <returns>The tool executable name.</returns>
+        protected override System.Collections.Generic.IEnumerable<string> GetToolExecutableNames()
         {
-            return _globber.GetFiles("./tools/**/xunit.console.clr4.exe").FirstOrDefault();
+            return new[] { "xunit.console.clr4.exe" };
         }
     }
 }

--- a/src/Cake.Core/Utilities/Tool.cs
+++ b/src/Cake.Core/Utilities/Tool.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Cake.Core.IO;
 
 namespace Cake.Core.Utilities
@@ -13,6 +15,7 @@ namespace Cake.Core.Utilities
         private readonly IFileSystem _fileSystem;        
         private readonly ICakeEnvironment _environment;
         private readonly IProcessRunner _processRunner;
+        private readonly IGlobber _globber;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tool{TSettings}" /> class.
@@ -20,7 +23,8 @@ namespace Cake.Core.Utilities
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
-        protected Tool(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner)
+        /// <param name="globber">The globber.</param>
+        protected Tool(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber)
         {
             if (fileSystem == null)
             {
@@ -34,10 +38,15 @@ namespace Cake.Core.Utilities
             {
                 throw new ArgumentNullException("processRunner");
             }
+            if (globber == null)
+            {
+                throw new ArgumentNullException("globber");
+            }
 
             _fileSystem = fileSystem;            
             _environment = environment;
             _processRunner = processRunner;
+            _globber = globber;
         }
 
         /// <summary>
@@ -148,10 +157,59 @@ namespace Cake.Core.Utilities
             {
                 return toolPath.MakeAbsolute(_environment);
             }
-            var defaultToolPath = GetDefaultToolPath(settings);
-            return defaultToolPath != null
-                ? defaultToolPath.MakeAbsolute(_environment)
-                : null;
+
+            var toolExeNames = GetToolExecutableNames();
+            IEnumerable<string> pathDirs = null;
+
+            // Look for each possible executable name in various places
+            foreach (var toolExeName in toolExeNames)
+            {                
+                // First look in ./tools/
+                toolPath = _globber.GetFiles("./tools/**/" + toolExeName).FirstOrDefault();
+                if (toolPath != null)
+                {
+                    return toolPath.MakeAbsolute(_environment);
+                }
+
+                // Cache the PATH directory list if we didn't already
+                if (pathDirs == null) 
+                {                    
+                    var pathEnv = _environment.GetEnvironmentVariable("PATH");
+                    if (!string.IsNullOrEmpty(pathEnv))
+                    {
+                        pathDirs = pathEnv.Split(_environment.IsUnix() ? ':' : ';');
+                    }
+                    else
+                    {
+                        pathDirs = Enumerable.Empty<string>();
+                    }
+                }
+
+                // Look in every PATH directory for the file
+                foreach (var pathDir in pathDirs)
+                {
+                    var file = new DirectoryPath(pathDir).CombineWithFilePath(toolExeName);
+
+                    if (_fileSystem.Exist(file))
+                    {
+                        return file.MakeAbsolute(_environment);
+                    }
+                }
+            }
+
+            var alternativePaths = GetAlternativeToolPaths(settings) ??
+                    Enumerable.Empty<FilePath>();
+
+            // Look through all the alternative directories for the tool
+            foreach (var altPath in alternativePaths)
+            {
+                if (_fileSystem.Exist(altPath))
+                {
+                    return altPath.MakeAbsolute(_environment);
+                }
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -159,6 +217,12 @@ namespace Cake.Core.Utilities
         /// </summary>
         /// <returns>The name of the tool.</returns>
         protected abstract string GetToolName();
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected abstract IEnumerable<string> GetToolExecutableNames();
 
         /// <summary>
         /// Gets the working directory.
@@ -172,10 +236,13 @@ namespace Cake.Core.Utilities
         }
 
         /// <summary>
-        /// Gets the default tool path.
+        /// Gets alternative file paths which the tool may exist in
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The default tool path.</returns>
-        protected abstract FilePath GetDefaultToolPath(TSettings settings);
+        protected virtual IEnumerable<FilePath> GetAlternativeToolPaths(TSettings settings)
+        {
+            return Enumerable.Empty<FilePath>();
+        }
     }
 }


### PR DESCRIPTION
This moves the responsibility of tool resolution over to the Tool base class.

It will check first of all in `./tools/**/TOOLNAME` then it will look in the PATH environment variable  directories for the tool, finally it will see if the tool implementation suggests any alternative paths where the tool might exist (eg: on unix, `/usr/bin/nuget` might work).

So each tool implementation now provides possible tool executable names (eg: `nuget.exe` and `NuGet.exe`) as well as optionally additional paths to look for the tool (eg: `/usr/bin/nuget`), and the base class will handle the rest.
